### PR TITLE
restore: allow snapshot path as a argument

### DIFF
--- a/bin/recover.sh
+++ b/bin/recover.sh
@@ -169,7 +169,6 @@ etcd_member_add() {
   HOSTNAME=$(hostname)
   HOSTDOMAIN=$(hostname -d)
   ETCD_NAME=etcd-member-${HOSTNAME}.${HOSTDOMAIN}
-  IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
 
   if [ -e $ASSET_DIR/backup/etcd/member/snap/db ]; then
     echo -e "Backup found removing exising data-dir"


### PR DESCRIPTION
Currently, we assume that the snapshot we are restoring is local. This is only true in the case where we are restoring a single node with no valid snapshot. This PR allows user to pass a snapshot file path used as an argument to the script for use in full cluster restore.
