### PR TITLE
*: add generate-etcd-conf.sh

### DIFF
--- a/bin/generate-etcd-conf.sh
+++ b/bin/generate-etcd-conf.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+usage () {
+    echo 'Input and output file required: ./script.sh config.in mc.out'
+    exit
+}
+
+if [ "$1" == "" ] || [ "$2" == "" ]; then
+    usage
+fi
+
+if ! [ -x "$(command -v urlencode)" ]; then
+  echo 'Error: urlencode is not installed and is required.' >&2
+  exit 1
+fi
+
+IN_RAW=$(cat "$1")
+OUT="$2"
+
+gen_config() {
+  URL_ENCODED_CONTENT=$(urlencode "$IN_RAW")
+
+  read -r -d '' TEMPLATE << EOF
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-etcd-conf
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,${URL_ENCODED_CONTENT}
+        filesystem: root
+        mode: 0644
+        path: /etc/etcd/etcd.conf
+EOF
+    echo "${TEMPLATE}" > $OUT
+    echo "MachineConfig is now available $OUT"
+}
+
+gen_config


### PR DESCRIPTION
This is an example script of how to deploy an update to etcd.conf via machineconfig.

etcd.conf.new
```
#[member]
ETCD_SNAPSHOT_COUNT=100000
ETCD_HEARTBEAT_INTERVAL=100
ETCD_ELECTION_TIMEOUT=1000

#[storage]
ETCD_QUOTA_BACKEND_BYTES=7516192768

#[logging]
ETCD_DEBUG=false

#[profiling]
ETCD_ENABLE_PPROF=false

#[new stuff]
ETCD_CIPHER_SUITES="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
```

```
$ ./generate-etcd-conf.sh etcd.conf.new etcd.conf.machineconfig
$ oc create -f etcd.conf.machineconfig
```



